### PR TITLE
Implement OldBillContinue component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS Instructions
+
+## Coding Guidelines
+- Use **TypeScript** and **React** functional components.
+- Prefer arrow functions and keep indentation at four spaces.
+- Use Tailwind CSS utility classes for styling.
+- Import modules using the `@/` alias, e.g. `import axios from "@/lib/axios"`.
+- Reuse helper components such as `Loader`, `CustomCheckbox`, and `SearchableSelect` where possible.
+
+## Commands
+- Install dependencies with `npm install` (or `pnpm install` if available).
+- Run **lint** checks using `npm run lint` before committing.
+- Development server: `npm run dev`.
+- Build for production: `npm run build`.
+
+## Commit Messages
+- Use short present‑tense summaries (e.g. `Add patient search component`).
+- Include a concise description of what was changed.
+
+## Testing
+- Currently the project only provides `npm run lint` for automated checks.
+  Ensure this command succeeds before submitting code changes.
+

--- a/components/reception/OldBillContinue.tsx
+++ b/components/reception/OldBillContinue.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import CustomCheckbox from "@/components/form/CustomCheckbox";
+import SearchableSelect from "@/components/form/SearchableSelect";
+import Loader from "@/components/form/Loader";
+import axios from "@/lib/axios";
+import { Option } from "@/types/interfaces";
+
+interface OldBillContinueProps {
+    userId?: number | string;
+    onSelectReferedBillId: (billId: number) => void;
+}
+
+const OldBillContinue: React.FC<OldBillContinueProps> = ({ userId, onSelectReferedBillId }) => {
+    const [checked, setChecked] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [bills, setBills] = useState<Option[]>([]);
+    const [selectedBill, setSelectedBill] = useState<Option>();
+
+    useEffect(() => {
+        if (checked && userId) {
+            setLoading(true);
+            axios
+                .get(`/api/users/bills/latest`, { params: { user_id: userId } })
+                .then((response) => {
+                    const options: Option[] = (response.data || []).map((bill: any) => ({
+                        value: bill.id.toString(),
+                        label: bill.label || `Bill #${bill.id}`,
+                    }));
+                    setBills(options);
+                })
+                .catch(() => setBills([]))
+                .finally(() => setLoading(false));
+        } else {
+            setBills([]);
+            setSelectedBill(undefined);
+        }
+    }, [checked, userId]);
+
+    const handleSelectBill = (option: Option | string | undefined) => {
+        if (option && typeof option !== "string") {
+            const opt = option as Option;
+            setSelectedBill(opt);
+            onSelectReferedBillId(Number(opt.value));
+        }
+    };
+
+    return (
+        <div className="my-4">
+            <CustomCheckbox label="Continue from old bill" checked={checked} setChecked={setChecked} />
+            {checked && (
+                <div className="mt-2">
+                    {loading ? (
+                        <div className="my-2 text-center">
+                            <Loader />
+                        </div>
+                    ) : (
+                        <SearchableSelect
+                            id="old_bill_select"
+                            placeholder="Select Bill"
+                            options={bills}
+                            value={selectedBill}
+                            onChange={(opt) => handleSelectBill(opt as Option)}
+                        />
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default OldBillContinue;


### PR DESCRIPTION
## Summary
- implement `OldBillContinue` component under reception folder
- show dropdown of user's recent bills when checkbox is checked
- fetch bills from `/api/users/bills/latest` endpoint and emit selected bill id
- add repository instructions in AGENTS.md

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Chrome download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685c19a303448329a83dcdd424441e33